### PR TITLE
adding result publisher and consumer chain

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,27 +1,70 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
-	"github.com/Bu1raj/byte-forge-backend/internal/api"
-	"github.com/Bu1raj/byte-forge-backend/internal/queue"
+	"github.com/Bu1raj/byte-forge-backend/internal/background"
+	"github.com/Bu1raj/byte-forge-backend/internal/store"
 )
 
-//TODO need to store these in vault
-const BROKER = "localhost:9092"
-const TOPIC = "submissions"
-
-func initializeKafkaProducer() *queue.Producer{
-	return queue.NewProducer(BROKER, TOPIC)
+// TODO this should come from vault or env vars
+var config = &store.KafkaStoreConfig{
+	Broker:         "localhost:9092",
+	ProducerTopics: []string{"submissions"},
+	ConsumerTopics: []string{"results"},
 }
 
 func main() {
-	http.Handle("/submit", &api.SubmitHandler{
-		Producer: initializeKafkaProducer(),
-	})
-	// http.HandleFunc("/result/", api.ResultHandler)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	log.Println("listening :8080")
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	var wg sync.WaitGroup
+
+	// Initialize Kafka producers and start the consumers
+	store.InitKafkaUtilStore(config)
+	background.StartResultConsumer(ctx, &wg)
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux)
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	// Start the HTTP server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		log.Println("listening :8080")
+
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server failed: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("shutting down the server gracefully...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP server Shutdown: %v", err)
+	}
+
+	log.Println("waiting for background tasks to finish...")
+	wg.Wait()
+	log.Println("all background tasks finished")
+
+	log.Println("closing all kafka connections...")
+	store.CloseAll()
+	log.Println("all kafka connections closed")
+	log.Println("server stopped")
 }

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+
+	code_submissions "github.com/Bu1raj/byte-forge-backend/internal/api/code_submissions"
+)
+
+// RegisterRoutes registers the HTTP routes for the server.
+func RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/submit", code_submissions.SubmitHandler)
+	mux.HandleFunc("/result/", code_submissions.ResultHandler)
+}

--- a/internal/background/result_consumer.go
+++ b/internal/background/result_consumer.go
@@ -1,0 +1,46 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"sync"
+
+	"github.com/Bu1raj/byte-forge-backend/internal/models"
+	"github.com/Bu1raj/byte-forge-backend/internal/store"
+	"github.com/segmentio/kafka-go"
+)
+
+// StartResultConsumer starts a background consumer to listen for code execution results
+func StartResultConsumer(ctx context.Context, wg *sync.WaitGroup) {
+	result_consumer, ok := store.GetConsumer("results")
+	if !ok {
+		log.Println("Results consumer not found in store")
+		return
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		log.Printf("Starting results consumer on topic: results")
+		err := result_consumer.Consume(ctx, ResultConsumerHandler)
+		if err != nil {
+			log.Printf("Result consumer stopped: %v", err)
+		}
+	}()
+}
+
+// ResultConsumerHandler processes messages from the results topic and stores them.
+func ResultConsumerHandler(msg *kafka.Message) error {
+	var payload models.KafkaCodeResultsPayload
+	if err := json.Unmarshal(msg.Value, &payload); err != nil {
+		log.Printf("Failed to unmarshal result payload: %v", err)
+		return err
+	}
+	err := store.StoreResult(payload.ID, payload.Result)
+	if err != nil {
+		log.Printf("Failed to store result for %s: %v", payload.ID, err)
+		return err
+	}
+	log.Printf("Stored result for %s", payload.ID)
+	return nil
+}

--- a/internal/models/submissions.go
+++ b/internal/models/submissions.go
@@ -20,3 +20,8 @@ type KafkaCodeSubmissionsPayload struct {
 	ID            string    `json:"id"`
 	SubmitRequest SubmitReq `json:"submit_request"`
 }
+
+type KafkaCodeResultsPayload struct {
+	ID     string `json:"id"`
+	Result Result `json:"result"`
+}

--- a/internal/queue/producer.go
+++ b/internal/queue/producer.go
@@ -45,3 +45,8 @@ func (p *Producer) SendMessage(msg []byte) error {
 
 	return nil
 }
+
+// Close closes the Kafka writer.
+func (p *Producer) Close() error {
+	return p.writer.Close()
+}

--- a/internal/store/kafka_store.go
+++ b/internal/store/kafka_store.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"log"
+	"sync"
+
+	"github.com/Bu1raj/byte-forge-backend/internal/queue"
+)
+
+type KafkaStoreConfig struct {
+	Broker         string
+	ProducerTopics []string
+	ConsumerTopics []string
+}
+
+type kafkaUtilStore struct {
+	broker    string
+	producers map[string]*queue.Producer
+	consumers map[string]*queue.Consumer
+	mu        sync.Mutex
+}
+
+var (
+	globalKafkaUtilStore *kafkaUtilStore
+)
+
+// Init initializes all Kafka producers/consumers once at startup
+func InitKafkaUtilStore(config *KafkaStoreConfig) {
+	log.Println("[store] initializing kafka store...")
+
+	globalKafkaUtilStore = &kafkaUtilStore{
+		broker:    config.Broker,
+		producers: make(map[string]*queue.Producer),
+		consumers: make(map[string]*queue.Consumer),
+	}
+
+	for _, topic := range config.ProducerTopics {
+		globalKafkaUtilStore.producers[topic] = queue.NewProducer(config.Broker, topic)
+	}
+	for _, topic := range config.ConsumerTopics {
+		globalKafkaUtilStore.consumers[topic] = queue.NewConsumer(config.Broker, topic, topic+"-group")
+	}
+	log.Println("[store] kafka store initialized")
+}
+
+// TODO Can add methods to register new producers/consumers dynamically if needed
+// Can also add methods to unregister/close the producers/consumers
+
+// GetProducer retrieves the producer for the given topic.
+// It returns the producer and a boolean indicating if it exists.
+func GetProducer(topic string) (*queue.Producer, bool) {
+	globalKafkaUtilStore.mu.Lock()
+	defer globalKafkaUtilStore.mu.Unlock()
+	producer, exists := globalKafkaUtilStore.producers[topic]
+	return producer, exists
+}
+
+// GetConsumer retrieves the consumer for the given topic.
+// It returns the consumer and a boolean indicating if it exists.
+func GetConsumer(topic string) (*queue.Consumer, bool) {
+	globalKafkaUtilStore.mu.Lock()
+	defer globalKafkaUtilStore.mu.Unlock()
+	consumer, exists := globalKafkaUtilStore.consumers[topic]
+	return consumer, exists
+}
+
+// CloseAll closes all registered producers and consumers.
+func CloseAll() {
+	globalKafkaUtilStore.mu.Lock()
+	defer globalKafkaUtilStore.mu.Unlock()
+	for _, producer := range globalKafkaUtilStore.producers {
+		producer.Close()
+	}
+	for _, consumer := range globalKafkaUtilStore.consumers {
+		consumer.Close()
+	}
+}

--- a/internal/store/results_store.go
+++ b/internal/store/results_store.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Bu1raj/byte-forge-backend/internal/models"
+)
+
+var (
+	results sync.Map // map[string]models.SubmissionResult
+)
+
+// StoreResult stores the result for a given job ID.
+func StoreResult(id string, result interface{}) error {
+	if id == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
+	if res, ok := result.(models.Result); ok {
+		results.Store(id, res)
+		return nil
+	}
+	return fmt.Errorf("invalid result type")
+}
+
+// GetResult retrieves the result for a given job ID.
+// It returns the result and a boolean indicating if it exists.
+func GetResult(id string) (models.Result, bool) {
+	val, ok := results.Load(id)
+	if !ok {
+		return models.Result{}, false
+	}
+	if res, ok := val.(models.Result); ok {
+		return res, true
+	}
+	return models.Result{}, false
+}


### PR DESCRIPTION
Have enabled the worker to publish results to the `results` topic, and added a consumer on the main server to listen to the results and store it in a `sync.Map`, also have added the `/results` endpoint which can be used for polling and fetching the code submission results